### PR TITLE
Finer-grained inline constant cache invalidation

### DIFF
--- a/benchmark/constant_invalidation.rb
+++ b/benchmark/constant_invalidation.rb
@@ -1,0 +1,22 @@
+$VERBOSE = nil
+
+CONSTANT1 = 1
+CONSTANT2 = 1
+CONSTANT3 = 1
+CONSTANT4 = 1
+CONSTANT5 = 1
+
+def constants
+  [CONSTANT1, CONSTANT2, CONSTANT3, CONSTANT4, CONSTANT5]
+end
+
+500_000.times do
+  constants
+
+  # With previous behavior, this would cause all of the constant caches
+  # associated with the constant lookups listed above to invalidate, meaning
+  # they would all have to be fetched again. With current behavior, it only
+  # invalidates when a name matches, so the following constant set shouldn't
+  # impact the constant lookups listed above.
+  INVALIDATE = true
+end

--- a/bootstraptest/test_constant_cache.rb
+++ b/bootstraptest/test_constant_cache.rb
@@ -1,0 +1,187 @@
+# Constant lookup is cached.
+assert_equal '1', %q{
+  CONST = 1
+
+  def const
+    CONST
+  end
+
+  const
+  const
+}
+
+# Invalidate when a constant is set.
+assert_equal '2', %q{
+  CONST = 1
+
+  def const
+    CONST
+  end
+
+  const
+
+  CONST = 2
+
+  const
+}
+
+# Invalidate when a constant of the same name is set.
+assert_equal '1', %q{
+  CONST = 1
+
+  def const
+    CONST
+  end
+
+  const
+
+  class Container
+    CONST = 2
+  end
+
+  const
+}
+
+# Invalidate when a constant is removed.
+assert_equal 'missing', %q{
+  class Container
+    CONST = 1
+
+    def const
+      CONST
+    end
+
+    def self.const_missing(name)
+      'missing'
+    end
+
+    new.const
+    remove_const :CONST
+  end
+
+  Container.new.const
+}
+
+# Invalidate when a constant's visibility changes.
+assert_equal 'missing', %q{
+  class Container
+    CONST = 1
+
+    def self.const_missing(name)
+      'missing'
+    end
+  end
+
+  def const
+    Container::CONST
+  end
+
+  const
+
+  Container.private_constant :CONST
+
+  const
+}
+
+# Invalidate when a constant's visibility changes even if the call to the
+# visibility change method fails.
+assert_equal 'missing', %q{
+  class Container
+    CONST1 = 1
+
+    def self.const_missing(name)
+      'missing'
+    end
+  end
+
+  def const1
+    Container::CONST1
+  end
+
+  const1
+
+  begin
+    Container.private_constant :CONST1, :CONST2
+  rescue NameError
+  end
+
+  const1
+}
+
+# Invalidate when a module is included.
+assert_equal 'INCLUDE', %q{
+  module Include
+    CONST = :INCLUDE
+  end
+
+  class Parent
+    CONST = :PARENT
+  end
+
+  class Child < Parent
+    def const
+      CONST
+    end
+
+    new.const
+
+    include Include
+  end
+
+  Child.new.const
+}
+
+# Invalidate when const_missing is hit.
+assert_equal '2', %q{
+  module Container
+    Foo = 1
+    Bar = 2
+
+    class << self
+      attr_accessor :count
+
+      def const_missing(name)
+        @count += 1
+        @count == 1 ? Foo : Bar
+      end
+    end
+
+    @count = 0
+  end
+
+  def const
+    Container::Baz
+  end
+
+  const
+  const
+}
+
+# Invalidate when the iseq gets cleaned up.
+assert_equal '2', %q{
+  CONSTANT = 1
+
+  iseq = RubyVM::InstructionSequence.compile(<<~RUBY)
+    CONSTANT
+  RUBY
+
+  iseq.eval
+  iseq = nil
+
+  GC.start
+  CONSTANT = 2
+}
+
+# Invalidate when the iseq gets cleaned up even if it was never in the cache.
+assert_equal '2', %q{
+  CONSTANT = 1
+
+  iseq = RubyVM::InstructionSequence.compile(<<~RUBY)
+    CONSTANT
+  RUBY
+
+  iseq = nil
+
+  GC.start
+  CONSTANT = 2
+}

--- a/class.c
+++ b/class.c
@@ -1161,11 +1161,20 @@ module_in_super_chain(const VALUE klass, VALUE module)
     return false;
 }
 
+// For each ID key in the class constant table, we're going to clear the VM's
+// inline constant caches associated with it.
+static enum rb_id_table_iterator_result
+clear_constant_cache_i(ID id, VALUE value, void *data)
+{
+    rb_clear_constant_cache_for_id(id);
+    return ID_TABLE_CONTINUE;
+}
+
 static int
 do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super, bool check_cyclic)
 {
     VALUE p, iclass, origin_stack = 0;
-    int method_changed = 0, constant_changed = 0, add_subclass;
+    int method_changed = 0, add_subclass;
     long origin_len;
     VALUE klass_origin = RCLASS_ORIGIN(klass);
     VALUE original_klass = klass;
@@ -1258,12 +1267,11 @@ do_include_modules_at(const VALUE klass, VALUE c, VALUE module, int search_super
 	}
 
         tbl = RCLASS_CONST_TBL(module);
-	if (tbl && rb_id_table_size(tbl)) constant_changed = 1;
+	if (tbl && rb_id_table_size(tbl))
+        rb_id_table_foreach(tbl, clear_constant_cache_i, (void *) 0);
       skip:
 	module = RCLASS_SUPER(module);
     }
-
-    if (constant_changed) rb_clear_constant_cache();
 
     return method_changed;
 }

--- a/include/ruby/internal/intern/vm.h
+++ b/include/ruby/internal/intern/vm.h
@@ -253,6 +253,13 @@ void rb_undef_alloc_func(VALUE klass);
 rb_alloc_func_t rb_get_alloc_func(VALUE klass);
 
 /**
+ * Clears the inline constant caches associated with a particular ID. Extension
+ * libraries should not bother with such things. Just forget about this API (or
+ * even, the presence of constant caches).
+ */
+void rb_clear_constant_cache_for_id(ID id);
+
+/**
  * Resembles `alias`.
  *
  * @param[out]  klass            Where to define an alias.

--- a/insns.def
+++ b/insns.def
@@ -1028,12 +1028,23 @@ opt_getinlinecache
 (VALUE val)
 {
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
+
+    // If there isn't an entry, then we're going to walk through the ISEQ
+    // starting at this instruction until we get to the associated
+    // opt_setinlinecache and associate this inline cache with every getconstant
+    // listed in between. We're doing this here instead of when the instructions
+    // are first compiled because it's possible to turn off inline caches and we
+    // want this to work in either case.
+    if (!ice) {
+        vm_ic_compile(GET_CFP(), ic);
+    }
+
     if (ice && vm_ic_hit_p(ice, GET_EP())) {
         val = ice->value;
         JUMP(dst);
     }
     else {
-	val = Qnil;
+        val = Qnil;
     }
 }
 

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -47,7 +47,6 @@ VALUE rb_obj_is_thread(VALUE obj);
 void rb_vm_mark(void *ptr);
 void rb_vm_each_stack_value(void *ptr, void (*cb)(VALUE, void*), void *ctx);
 PUREFUNC(VALUE rb_vm_top_self(void));
-void rb_vm_inc_const_missing_count(void);
 const void **rb_vm_get_insns_address_table(void);
 VALUE rb_source_location(int *pline);
 const char *rb_source_location_cstr(int *pline);

--- a/iseq.c
+++ b/iseq.c
@@ -102,12 +102,64 @@ compile_data_free(struct iseq_compile_data *compile_data)
     }
 }
 
+struct iseq_clear_ic_references_data {
+    IC ic;
+};
+
+// This iterator is used to walk through the instructions and clean any
+// references to ICs that are contained within this ISEQ out of the VM's
+// constant cache table. It passes around a struct that holds the current IC
+// we're looking for, which can be NULL (if we haven't hit an opt_getinlinecache
+// instruction yet) or set to an IC (if we've hit an opt_getinlinecache and
+// haven't yet hit the associated opt_setinlinecache).
+static bool
+iseq_clear_ic_references_i(VALUE *code, VALUE insn, size_t index, void *data)
+{
+    struct iseq_clear_ic_references_data *ic_data = (struct iseq_clear_ic_references_data *) data;
+
+    switch (insn) {
+        case BIN(opt_getinlinecache): {
+            ic_data->ic = (IC) code[index + 2];
+            return true;
+        }
+        case BIN(getconstant): {
+            ID id = (ID) code[index + 1];
+            rb_vm_t *vm = GET_VM();
+            st_table *ics;
+
+            if (rb_id_table_lookup(vm->constant_cache, id, (VALUE *) &ics)) {
+                st_delete(ics, (st_data_t *) &ic_data->ic, (st_data_t *) NULL);
+            }
+
+            return true;
+        }
+        case BIN(opt_setinlinecache): {
+            ic_data->ic = NULL;
+            return true;
+        }
+        default:
+            return true;
+    }
+}
+
+// When an ISEQ is being freed, all of its associated ICs are going to go away
+// as well. Because of this, we need to walk through the ISEQ, find any
+// opt_getinlinecache calls, and clear out the VM's constant cache of associated
+// ICs.
+static void
+iseq_clear_ic_references(const rb_iseq_t *iseq)
+{
+    struct iseq_clear_ic_references_data data = { .ic = NULL };
+    rb_iseq_each(iseq, 0, iseq_clear_ic_references_i, (void *) &data);
+}
+
 void
 rb_iseq_free(const rb_iseq_t *iseq)
 {
     RUBY_FREE_ENTER("iseq");
 
     if (iseq && iseq->body) {
+    iseq_clear_ic_references(iseq);
 	struct rb_iseq_constant_body *const body = iseq->body;
 	mjit_free_iseq(iseq); /* Notify MJIT */
         rb_yjit_iseq_free(body);
@@ -247,6 +299,39 @@ rb_iseq_each_value(const rb_iseq_t *iseq, iseq_value_itr_t * func, void *data)
 
     for (n = 0; n < size;) {
 	n += iseq_extract_values(code, n, func, data, translator);
+    }
+}
+
+// Similar to rb_iseq_each_value, except that this walks through each
+// instruction instead of the associated VALUEs. The provided iterator should
+// return a boolean that indicates whether or not to continue iterating.
+void
+rb_iseq_each(const rb_iseq_t *iseq, size_t start_index, rb_iseq_each_i iterator, void *data)
+{
+    unsigned int size;
+    VALUE *code;
+    size_t index;
+
+    rb_vm_insns_translator_t *const translator =
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+        (FL_TEST((VALUE)iseq, ISEQ_TRANSLATED)) ? rb_vm_insn_addr2insn2 :
+#endif
+        rb_vm_insn_null_translator;
+
+    const struct rb_iseq_constant_body *const body = iseq->body;
+
+    size = body->iseq_size;
+    code = body->iseq_encoded;
+
+    for (index = start_index; index < size;) {
+        void *addr = (void *) code[index];
+        VALUE insn = translator(addr);
+
+        if (!iterator(code, insn, index, data)) {
+            break;
+        }
+
+        index += insn_len(insn);
     }
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -182,6 +182,9 @@ void rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc,
 void rb_iseq_mark_insn_storage(struct iseq_compile_data_storage *arena);
 
 /* iseq.c */
+typedef bool rb_iseq_each_i(VALUE *code, VALUE insn, size_t index, void *data);
+void rb_iseq_each(const rb_iseq_t *iseq, size_t start_index, rb_iseq_each_i iterator, void *data);
+
 VALUE rb_iseq_load(VALUE data, VALUE parent, VALUE opt);
 VALUE rb_iseq_parameters(const rb_iseq_t *iseq, int is_proc);
 unsigned int rb_iseq_line_no(const rb_iseq_t *iseq, size_t pos);

--- a/test/ruby/test_rubyvm.rb
+++ b/test/ruby/test_rubyvm.rb
@@ -4,11 +4,11 @@ require 'test/unit'
 class TestRubyVM < Test::Unit::TestCase
   def test_stat
     assert_kind_of Hash, RubyVM.stat
-    assert_kind_of Integer, RubyVM.stat[:global_constant_state]
+    assert_kind_of Integer, RubyVM.stat[:class_serial]
 
     RubyVM.stat(stat = {})
     assert_not_empty stat
-    assert_equal stat[:global_constant_state], RubyVM.stat(:global_constant_state)
+    assert_equal stat[:class_serial], RubyVM.stat(:class_serial)
   end
 
   def test_stat_unknown

--- a/tool/ruby_vm/views/_mjit_compile_getinlinecache.erb
+++ b/tool/ruby_vm/views/_mjit_compile_getinlinecache.erb
@@ -13,9 +13,9 @@
 
 % # compiler: Capture IC values, locking getinlinecache
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
-    if (ice != NULL && GET_IC_SERIAL(ice) && !status->compile_info->disable_const_cache) {
+    if (ice != NULL && !status->compile_info->disable_const_cache) {
 %       # JIT: Inline everything in IC, and cancel the slow path
-        fprintf(f, "    if (vm_inlined_ic_hit_p(0x%"PRIxVALUE", 0x%"PRIxVALUE", (const rb_cref_t *)0x%"PRIxVALUE", %"PRI_SERIALT_PREFIX"u, reg_cfp->ep)) {", ice->flags, ice->value, (VALUE)ice->ic_cref, GET_IC_SERIAL(ice));
+        fprintf(f, "    if (vm_inlined_ic_hit_p(0x%"PRIxVALUE", 0x%"PRIxVALUE", (const rb_cref_t *)0x%"PRIxVALUE", reg_cfp->ep)) {", ice->flags, ice->value, (VALUE)ice->ic_cref);
         fprintf(f, "        stack[%d] = 0x%"PRIxVALUE";\n", b->stack_size, ice->value);
         fprintf(f, "        goto label_%d;\n", pos + insn_len(insn) + (int)dst);
         fprintf(f, "    }");

--- a/variable.c
+++ b/variable.c
@@ -2848,7 +2848,7 @@ rb_const_remove(VALUE mod, ID id)
         undefined_constant(mod, ID2SYM(id));
     }
 
-    rb_clear_constant_cache();
+    rb_clear_constant_cache_for_id(id);
 
     val = ce->value;
     if (val == Qundef) {
@@ -3132,7 +3132,7 @@ rb_const_set(VALUE klass, ID id, VALUE val)
         struct rb_id_table *tbl = RCLASS_CONST_TBL(klass);
         if (!tbl) {
             RCLASS_CONST_TBL(klass) = tbl = rb_id_table_create(0);
-            rb_clear_constant_cache();
+            rb_clear_constant_cache_for_id(id);
             ce = ZALLOC(rb_const_entry_t);
             rb_id_table_insert(tbl, id, (VALUE)ce);
             setup_const_entry(ce, klass, val, CONST_PUBLIC);
@@ -3210,7 +3210,7 @@ const_tbl_update(struct autoload_const *ac)
 	    struct autoload_data_i *ele = current_autoload_data(klass, id, &ac);
 
 	    if (ele) {
-		rb_clear_constant_cache();
+		rb_clear_constant_cache_for_id(id);
 
 		ac->value = val; /* autoload_i is non-WB-protected */
                 ac->file = rb_source_location(&ac->line);
@@ -3238,11 +3238,11 @@ const_tbl_update(struct autoload_const *ac)
 				"previous definition of %"PRIsVALUE" was here", name);
 	    }
 	}
-	rb_clear_constant_cache();
+	rb_clear_constant_cache_for_id(id);
 	setup_const_entry(ce, klass, val, visibility);
     }
     else {
-	rb_clear_constant_cache();
+	rb_clear_constant_cache_for_id(id);
 
 	ce = ZALLOC(rb_const_entry_t);
 	rb_id_table_insert(tbl, id, (VALUE)ce);
@@ -3297,10 +3297,6 @@ set_const_visibility(VALUE mod, int argc, const VALUE *argv,
 	VALUE val = argv[i];
 	id = rb_check_id(&val);
 	if (!id) {
-	    if (i > 0) {
-		rb_clear_constant_cache();
-	    }
-
             undefined_constant(mod, val);
 	}
 	if ((ce = rb_const_lookup(mod, id))) {
@@ -3315,15 +3311,12 @@ set_const_visibility(VALUE mod, int argc, const VALUE *argv,
 		    ac->flag |= flag;
 		}
 	    }
+        rb_clear_constant_cache_for_id(id);
 	}
 	else {
-	    if (i > 0) {
-		rb_clear_constant_cache();
-	    }
             undefined_constant(mod, ID2SYM(id));
 	}
     }
-    rb_clear_constant_cache();
 }
 
 void

--- a/vm_core.h
+++ b/vm_core.h
@@ -229,43 +229,13 @@ struct iseq_inline_constant_cache_entry {
     VALUE flags;
 
     VALUE value;              // v0
-    union ic_serial_entry ic_serial; // v1, v2
+    VALUE _unused1;           // v1
+    VALUE _unused2;           // v2
     const rb_cref_t *ic_cref; // v3
 };
 STATIC_ASSERT(sizeof_iseq_inline_constant_cache_entry,
               (offsetof(struct iseq_inline_constant_cache_entry, ic_cref) +
 	       sizeof(const rb_cref_t *)) <= sizeof(struct RObject));
-
-#if SIZEOF_SERIAL_T <= SIZEOF_VALUE
-
-#define GET_IC_SERIAL(ice) (ice)->ic_serial.raw
-#define SET_IC_SERIAL(ice, v) (ice)->ic_serial.raw = (v)
-
-#else
-
-static inline rb_serial_t
-get_ic_serial(const struct iseq_inline_constant_cache_entry *ice)
-{
-    union ic_serial_entry tmp;
-    tmp.data[0] = ice->ic_serial.data[0];
-    tmp.data[1] = ice->ic_serial.data[1];
-    return tmp.raw;
-}
-
-#define GET_IC_SERIAL(ice) get_ic_serial(ice)
-
-static inline void
-set_ic_serial(struct iseq_inline_constant_cache_entry *ice, rb_serial_t v)
-{
-    union ic_serial_entry tmp;
-    tmp.raw = v;
-    ice->ic_serial.data[0] = tmp.data[0];
-    ice->ic_serial.data[1] = tmp.data[1];
-}
-
-#define SET_IC_SERIAL(ice, v) set_ic_serial((ice), (v))
-
-#endif
 
 struct iseq_inline_constant_cache {
     struct iseq_inline_constant_cache_entry *entry;
@@ -719,6 +689,12 @@ typedef struct rb_vm_struct {
 
     struct rb_id_table *negative_cme_table;
     st_table *overloaded_cme_table; // cme -> overloaded_cme
+
+    // This id table contains a mapping from ID to ICs. It does this with ID
+    // keys and nested st_tables as values. The nested tables have ICs as keys
+    // and Qtrue as values. It is used when inline constant caches need to be
+    // invalidated or ISEQs are being freed.
+    struct rb_id_table *constant_cache;
 
 #ifndef VM_GLOBAL_CC_CACHE_TABLE_SIZE
 #define VM_GLOBAL_CC_CACHE_TABLE_SIZE 1023

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -14,7 +14,6 @@
 MJIT_SYMBOL_EXPORT_BEGIN
 
 RUBY_EXTERN VALUE ruby_vm_const_missing_count;
-RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
 RUBY_EXTERN rb_serial_t ruby_vm_class_serial;
 RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 
@@ -183,8 +182,6 @@ CC_SET_FASTPATH(const struct rb_callcache *cc, vm_call_handler func, bool enable
 
 #define PREV_CLASS_SERIAL() (ruby_vm_class_serial)
 #define NEXT_CLASS_SERIAL() (++ruby_vm_class_serial)
-#define GET_GLOBAL_CONSTANT_STATE() (ruby_vm_global_constant_state)
-#define INC_GLOBAL_CONSTANT_STATE() (++ruby_vm_global_constant_state)
 #define GET_GLOBAL_CVAR_STATE() (ruby_vm_global_cvar_state)
 #define INC_GLOBAL_CVAR_STATE() (++ruby_vm_global_cvar_state)
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -126,11 +126,27 @@ vm_cme_invalidate(rb_callable_method_entry_t *cme)
     rb_yjit_cme_invalidate((VALUE)cme);
 }
 
-void
-rb_clear_constant_cache(void)
+static int
+rb_clear_constant_cache_for_id_i(st_data_t ic, st_data_t idx, st_data_t arg)
 {
+    ((IC) ic)->entry = NULL;
+    return ST_CONTINUE;
+}
+
+// Here for backward compat.
+void rb_clear_constant_cache() {}
+
+void
+rb_clear_constant_cache_for_id(ID id)
+{
+    rb_vm_t *vm = GET_VM();
+    st_table *ics;
+
+    if (rb_id_table_lookup(vm->constant_cache, id, (VALUE *) &ics)) {
+        st_foreach(ics, rb_clear_constant_cache_for_id_i, (st_data_t) NULL);
+    }
+
     rb_yjit_constant_state_changed();
-    INC_GLOBAL_CONSTANT_STATE();
 }
 
 static void

--- a/yjit_codegen.c
+++ b/yjit_codegen.c
@@ -4438,8 +4438,6 @@ gen_leave(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
     return YJIT_END_BLOCK;
 }
 
-RUBY_EXTERN rb_serial_t ruby_vm_global_constant_state;
-
 static codegen_status_t
 gen_getglobal(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 {
@@ -4707,8 +4705,7 @@ gen_opt_getinlinecache(jitstate_t *jit, ctx_t *ctx, codeblock_t *cb)
 
     // See vm_ic_hit_p(). The same conditions are checked in yjit_constant_ic_update().
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
-    if (!ice || // cache not filled
-        GET_IC_SERIAL(ice) != ruby_vm_global_constant_state /* cache out of date */) {
+    if (!ice) {
         // In these cases, leave a block that unconditionally side exits
         // for the interpreter to invalidate.
         return YJIT_CANT_COMPILE;


### PR DESCRIPTION
When a constant expression appears in code, Ruby adds an inline cache object into the associated instruction sequence. That inline cache keeps track of the value of the constant the last time it was looked up so that it doesn't have to be fetched each time that instruction is executed.

This cache is invalidated any time:

* a constant is assigned (`X = 1`)
* a constant is removed (`remove_const(:X)`)
* a constant has its visibility changed (`private_constant(:X)`)
* a module is included (`include X`)
* a module is found to be missing through `const_missing`

Currently the way invalidation works is that every inline cache stores an integer representing the global constant state that was set the last time the value was fetched. If the global constant state has not changed (i.e., the values match) then the cache is hit. Otherwise, it's a cache miss, the value is refetched and the new global constant state is stored.

Unfortunately, some applications do undesirable things like setting constants at runtime, which ends up invalidating every cache in the application. This imposes a penalty on all of the subsequent constant lookups, which can add up to a lot of waste cycles. For example, if you had some code in your application that ran `X = 1` on every request (unlikely, but possible), your caches to `Y` and `Z` would always miss even though they're unrelated.

The current behavior also has serious implications for YJIT. Since YJIT specializes on runtime values, it _must_ rely upon consistent values for constants. Therefore we currently have to track which basic blocks have dependencies on the global constant state. If that global constant state changes, then we have to invalidate every basic block that depended on it, which means throwing out a whole bunch of generated code. Without code GC, this makes it even worse, because now we have dead code lying around taking up space in our allocated memory region.

This commit changes the behavior of our inline constant caches. Instead of relying on a global constant state, they instead just check if the cache has been populated. If the cache is empty, it performs the constant lookup again. So to invalidate the cache, we just clear the cache entry.

The first time the `opt_getinlinecache` instruction is hit the cache is empty. It sees this, and walks through the ISEQ to find all of the `getconstant` calls that exist between the `opt_getinlinecache` and the `opt_setinlinecache` instruction. For each of the `getconstant` instructions it pulls out the `ID` associated with it and puts it into the VM's new `constant_cache` `st_table`. The `st_table` contains all of the inline cache objects that are associated with that `ID`. We then insert the `IC` into that table in a nested `st_table`. So for example, if you ran the following code:

```ruby
[X, X::Y, Y]
```

You would get the following instructions:

```
== disasm: #<ISeq:<main>@test.rb:1 (1,0)-(1,12)> (catch: FALSE)
0000 opt_getinlinecache                     9, <is:0>                 (   1)[Li]
0003 putobject                              true
0005 getconstant                            :X
0007 opt_setinlinecache                     <is:0>
0009 opt_getinlinecache                     22, <is:1>
0012 putobject                              true
0014 getconstant                            :X
0016 putobject                              false
0018 getconstant                            :Y
0020 opt_setinlinecache                     <is:1>
0022 opt_getinlinecache                     31, <is:2>
0025 putobject                              true
0027 getconstant                            :Y
0029 opt_setinlinecache                     <is:2>
0031 newarray                               3
0033 leave
```

There are 3 inline caches in the ISEQ above (`is:0`, `is:1`, and `is:2`). The first would be associated with the `ID` `X`, the second with both `X` and `Y`, and the third with just `Y`. So you would end up with a table on the VM that looked something like:

```
{
  X => <is:0>, <is:1>
  Y => <is:1>, <is:2>
}
```

To invalidate the cache, previously we would increment the global constant state. In this new behavior, we instead determine which `ID`s need to be invaliated, and walk through the VM's table to clear out any caches associated with those `ID`s. So, for example, if we changed the value of `Y` in the previous example, we would be clearing the cache entries for `<is:1>` and `<is:2>`.